### PR TITLE
Use thumbnails where appropriate, misc fixes for excerpts and single templates.

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -83,7 +83,7 @@ function rechallenge_get_aux_page_id()
     } elseif (is_post_type_archive("job_opening") || is_singular('job_opening')) {
         $id = get_page_by_path("career/job-openings");
     } elseif (is_post_type_archive("event") || is_singular('event')) {
-        $id = get_page_by_path("activities/overview");
+        $id = get_page_by_path("activities");
     } elseif (is_home() || is_archive()) {
         $id = get_post(get_option("page_for_posts"));
     }

--- a/parts/footer/partners.php
+++ b/parts/footer/partners.php
@@ -40,7 +40,7 @@ if ($partners->have_posts()) { ?>
                             break;
                     }
 
-                    $thumb = get_the_post_thumbnail_url();
+                    $thumb = get_the_post_thumbnail_url(null, 'medium');
                     $style = $thumb ? ' style="background-image:url('.esc_url($thumb).')"' : '';
                     $class = 'class="'.($thumb ? 'img hidetext' : 'img').'"';
                     ?>

--- a/parts/post-type/excerpt-event.php
+++ b/parts/post-type/excerpt-event.php
@@ -37,13 +37,9 @@ $end = strtotime($meta['_event_end_date'][0]);
                 <?php if ($has_categories) { ?>
                     <span class="event-location">
                     <?php
-
-                    foreach ($categories as $item) {
-                        // TODO: restore when event categories are implemented
-                        /* <a href="<?php echo get_term_link($item->term_id); ?>"><?php echo $item->name; ?></a> */
-                        echo $item->name;
-                    }
-
+                    // TODO: restore when event categories are implemented
+                    /* <a href="<?php echo get_term_link($item->term_id); ?>"><?php echo $item->name; ?></a> */
+                    echo implode(', ', wp_list_pluck($categories, 'name'));
                     ?>
                 </span>
                     <?php
@@ -63,5 +59,5 @@ $end = strtotime($meta['_event_end_date'][0]);
         <?php echo isset($meta['_event_short_description']) ? wpautop($meta['_event_short_description'][0]) : ''; ?>
 
     </div>
-    
+
 </article>

--- a/parts/post-type/excerpt-post-list-item.php
+++ b/parts/post-type/excerpt-post-list-item.php
@@ -1,5 +1,5 @@
 <?php
-$thumb_url = has_post_thumbnail() ? get_the_post_thumbnail_url() : RECHALLENGE_URI.'/assets/images/placeholder.png';
+$thumb_url = has_post_thumbnail() ? get_the_post_thumbnail_url(null, 'medium') : RECHALLENGE_URI.'/assets/images/placeholder.png';
 ?>
 <li>
     <article class="icon-row">

--- a/parts/post-type/excerpt-post.php
+++ b/parts/post-type/excerpt-post.php
@@ -16,6 +16,9 @@ $thumb = get_the_post_thumbnail_url(get_the_ID(), "medium");
 
         <?php the_excerpt(); ?>
 
+        <p class="byline">
+            Posted <time pubdate="pubdate"><?php the_date('F jS, Y H:i'); ?></time>
+        </p>
     </div>
 
 </article>

--- a/parts/post-type/single-board.php
+++ b/parts/post-type/single-board.php
@@ -17,7 +17,7 @@ $with_photo = has_post_thumbnail() ? 'has-photo' : false;
         </div>
 
         <div class="large-5 column">
-            <a href="<?=esc_url(get_the_post_thumbnail_url())?>">
+            <a href="<?=esc_url(null, get_the_post_thumbnail_url(null, 'large'))?>">
                 <?php the_post_thumbnail('medium', [
                     'alt' => esc_attr(get_the_title()),
                 ]); ?>

--- a/parts/post-type/single-board.php
+++ b/parts/post-type/single-board.php
@@ -17,7 +17,7 @@ $with_photo = has_post_thumbnail() ? 'has-photo' : false;
         </div>
 
         <div class="large-5 column">
-            <a href="<?=esc_url(null, get_the_post_thumbnail_url(null, 'large'))?>">
+            <a href="<?=esc_url(get_the_post_thumbnail_url(null, 'large'))?>">
                 <?php the_post_thumbnail('medium', [
                     'alt' => esc_attr(get_the_title()),
                 ]); ?>

--- a/parts/post-type/single-committee.php
+++ b/parts/post-type/single-committee.php
@@ -4,7 +4,7 @@
     <?php if ($with_photo) { ?>
 
         <div class="large-5 column">
-            <a href="<?=esc_url(get_the_post_thumbnail_url())?>">
+            <a href="<?=esc_url(get_the_post_thumbnail_url(null, 'large'))?>">
                 <?php the_post_thumbnail('medium', [
                     'alt' => esc_attr(get_the_title()),
                 ]); ?>

--- a/parts/post-type/single-event.php
+++ b/parts/post-type/single-event.php
@@ -1,43 +1,28 @@
 <?php
 // Get post meta
 $meta = get_post_custom(get_the_ID());
-$location = !isset($meta['_event_location']) ? 'Unknown' : $meta['_event_location'][0];
-$start_ts =
-    !isset($meta['_event_start_date']) || empty($meta['_event_start_date'][0]) ? -1 :
-        strtotime($meta['_event_start_date'][0]);
-$end_ts = !isset($meta['_event_end_date']) ? -1 : strtotime($meta['_event_end_date'][0]);
-$cost_str = !isset($meta['_event_cost']) ? -1 : $meta['_event_cost'][0];
+$location = ! isset($meta['_event_location']) ? 'Unknown' : $meta['_event_location'][0];
+$start_ts = ! isset($meta['_event_start_date']) || empty($meta['_event_start_date'][0]) ? -1 : strtotime($meta['_event_start_date'][0]);
+$end_ts = ! isset($meta['_event_end_date']) ? -1 : strtotime($meta['_event_end_date'][0]);
+$cost_str = ! isset($meta['_event_cost']) ? -1 : $meta['_event_cost'][0];
 
 // Date
 $formatted_date = format_event_date($start_ts, $end_ts);
 
 // Products
-$product_ids = !isset($meta['_event_product_post_array']) ? [] : unserialize($meta['_event_product_post_array'][0]);
+$product_ids = ! isset($meta['_event_product_post_array']) ? [] : unserialize($meta['_event_product_post_array'][0]);
 
 // Categories
-$category_list = get_the_term_list(get_the_ID(), 'event_category', '', ', ', '');
+// TODO: restore when event categories are implemented
+// $category_list = get_the_term_list(get_the_ID(), 'event_category', '', ', ', '');
+$categories = get_the_terms(get_the_ID(), 'event_category');
+$category_list = implode(', ', wp_list_pluck($categories, 'name'));
 ?>
 
 
 <div class="row post-content">
 
-    <article class="column medium-7 large-8">
-
-        <?php
-        the_title('<h1>', '</h1>');
-        the_content();
-        ?>
-
-        <footer>
-            <?php get_template_part("parts/misc/share"); ?>
-        </footer>
-
-        <p class="events-backlink"><a class="button small" href="<?= site_url('/activities/'); ?>">&lsaquo; Back to
-                calendar</a></p>
-
-    </article>
-
-    <aside class="column medium-5 large-4">
+    <aside class="column column-block medium-5 large-4 medium-push-7 large-push-8">
 
         <div class="wisv-panel">
 
@@ -49,16 +34,16 @@ $category_list = get_the_term_list(get_the_ID(), 'event_category', '', ', ', '')
 
                 <?php if ($formatted_date[0]) { ?>
                     <ul class="fa-ul company-details">
-                        <li><i class="fa-li fa ch-clock-o"></i><?= esc_attr($formatted_date[0]) ?></li>
-                        <?php if (!empty($formatted_date[1])) { ?>
-                            <li>till <?= esc_attr($formatted_date[1]) ?></li>
+                        <li><i class="fa-li fa ch-clock-o"></i><?=esc_attr($formatted_date[0])?></li>
+                        <?php if (! empty($formatted_date[1])) { ?>
+                            <li>to <?=esc_attr($formatted_date[1])?></li>
                         <?php } ?>
                     </ul>
                 <?php } ?>
 
                 <?php if ($location) { ?>
                     <ul class="fa-ul company-details">
-                        <li><i class="fa-li fa ch-map-marker"></i><?= esc_attr($location) ?></li>
+                        <li><i class="fa-li fa ch-map-marker"></i><?=esc_attr($location)?></li>
                     </ul>
                 <?php } ?>
 
@@ -68,8 +53,8 @@ $category_list = get_the_term_list(get_the_ID(), 'event_category', '', ', ', '')
                         $product = get_post($product_ids[$i]);
                         $product_meta = get_post_custom($product_ids[$i]);
                         ?>
-                        <li><?= ($i === 0) ? '<i class="fa-li fa ch-money"></i>' : '' ?>
-                            &euro; <?= format_event_cost($product_meta['_product_cost'][0]) ?> <?= (count($product_ids) != 1) ? $product->post_title : '' ?>
+                        <li><?=($i === 0) ? '<i class="fa-li fa ch-money"></i>' : ''?>
+                            &euro; <?=format_event_cost($product_meta['_product_cost'][0])?> <?=(count($product_ids) != 1) ? $product->post_title : ''?>
                         </li>
                         <?php
                     }
@@ -79,7 +64,7 @@ $category_list = get_the_term_list(get_the_ID(), 'event_category', '', ', ', '')
 
                 <?php if ($category_list) { ?>
                     <ul class="fa-ul company-details">
-                        <li><i class="fa-li fa ch-tag"></i><?= $category_list ?></li>
+                        <li><i class="fa-li fa ch-tag"></i><?=$category_list?></li>
                     </ul>
                 <?php } ?>
 
@@ -90,18 +75,32 @@ $category_list = get_the_term_list(get_the_ID(), 'event_category', '', ', ', '')
         <?php
         if (has_post_thumbnail()) {
             ?>
-            <div class="wisv-panel">
-                <a href="<?= esc_url(get_the_post_thumbnail_url()) ?>">
-                    <?php the_post_thumbnail('medium',
-                        [
-                            'alt' => esc_attr(get_the_title()),
-                        ]); ?>
+            <div class="wisv-panel show-for-medium">
+                <a href="<?=esc_url(get_the_post_thumbnail_url(null, 'large'))?>">
+                    <?php the_post_thumbnail('medium', [
+                        'alt' => esc_attr(get_the_title()),
+                    ]); ?>
                 </a>
             </div>
             <?php
         }
         ?>
     </aside>
+
+    <article class="column medium-7 large-8 medium-pull-5 large-pull-4">
+
+        <?php
+        the_title('<h1>', '</h1>');
+        the_content();
+        ?>
+
+        <footer>
+            <?php get_template_part("parts/misc/share"); ?>
+        </footer>
+
+        <p class="events-backlink"><a class="button small" href="<?=site_url('/activities/');?>">&lsaquo; Back to calendar</a></p>
+
+    </article>
 
 </div>
 

--- a/parts/post-type/single-honorary_member.php
+++ b/parts/post-type/single-honorary_member.php
@@ -5,7 +5,7 @@
     if (has_post_thumbnail()) {
         ?>
 
-        <a href="<?=esc_url(get_the_post_thumbnail_url())?>" class="thumbnail float-right">
+        <a href="<?=esc_url(get_the_post_thumbnail_url(null, 'large'))?>" class="thumbnail float-right">
             <?php the_post_thumbnail('featured-image'); ?>
         </a>
 


### PR DESCRIPTION
Replace full-size images with thumbnails, add post time to news excerpt.

Fixes WISVCH/website#16.