### PR TITLE
Ambassador page design

### DIFF
--- a/parts/post-type/archive-ambassador.php
+++ b/parts/post-type/archive-ambassador.php
@@ -1,4 +1,4 @@
-<div class="row small-up-2 medium-up-4 large-up-6">
+<div class="row small-up-1 medium-up-2 large-up-4">
     <?php
     while (have_posts()) {
         the_post(); ?>

--- a/parts/post-type/archive-ambassador.php
+++ b/parts/post-type/archive-ambassador.php
@@ -1,4 +1,4 @@
-<div class="row small-up-1 medium-up-2 large-up-4">
+<div class="row small-up-1 medium-up-3 large-up-4">
     <?php
     while (have_posts()) {
         the_post(); ?>

--- a/parts/post-type/excerpt-ambassador.php
+++ b/parts/post-type/excerpt-ambassador.php
@@ -4,16 +4,21 @@ $meta = get_post_custom(get_the_ID());
 $ambassador_function = ! isset($meta['ambassador_function'][0]) ? '' : $meta['ambassador_function'][0];
 ?>
 <article class="excerpt-blockgrid excerpt-ambassador">
+  <div>
     <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
-        <div class="thumbnail nopad prop">
-            <?php include(locate_template('parts/misc/thumbnail-proportional.php')); ?>
-        </div>
-        <?php 
+      <div class="thumbnail nopad prop">
+        <?php include(locate_template('parts/misc/thumbnail-proportional.php')); ?>
+      </div>
+      <?php 
       the_title('<h2>', '</h2>');
-      
-          if (!empty($ambassador_function)) { ?>
-            <p class="byline"><?=esc_html($ambassador_function);?></p>
-      
-        <?php } ?>
+      ?>
     </a>
+      <?php 
+          if (!empty($ambassador_function)) { ?>
+            <p class="byline">
+              <?=esc_html($ambassador_function);?>
+            </p>
+      <?php }; ?>
+  
+  </div>
 </article>

--- a/parts/post-type/excerpt-ambassador.php
+++ b/parts/post-type/excerpt-ambassador.php
@@ -1,9 +1,19 @@
-<?php $thumb = get_the_post_thumbnail_url(get_the_ID(), "medium"); ?>
+<?php 
+$thumb = get_the_post_thumbnail_url(get_the_ID(), "medium"); 
+$meta = get_post_custom(get_the_ID());
+$ambassador_function = ! isset($meta['ambassador_function'][0]) ? '' : $meta['ambassador_function'][0];
+?>
 <article class="excerpt-blockgrid excerpt-ambassador">
     <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
         <div class="thumbnail nopad prop">
             <?php include(locate_template('parts/misc/thumbnail-proportional.php')); ?>
         </div>
-        <?php the_title('<h2>', '</h2>'); ?>
+        <?php 
+      the_title('<h2>', '</h2>');
+      
+          if (!empty($ambassador_function)) { ?>
+            <p class="byline"><?=esc_html($ambassador_function);?></p>
+      
+        <?php } ?>
     </a>
 </article>

--- a/parts/post-type/excerpt.php
+++ b/parts/post-type/excerpt.php
@@ -3,6 +3,7 @@
     <?php
     include(locate_template('parts/misc/thumbnail-proportional.php'));
     the_title('<h2>', '</h2>');
+  
     the_excerpt();
     ?>
 </a>

--- a/parts/post-type/single-ambassador.php
+++ b/parts/post-type/single-ambassador.php
@@ -9,7 +9,7 @@
         <?php
     }
 
-    the_title('<h2>', '</h2>');
+    the_title('<h1>', '</h1>');
 
     the_content();
     ?>

--- a/parts/post-type/single-ambassador.php
+++ b/parts/post-type/single-ambassador.php
@@ -9,7 +9,7 @@
         <?php
     }
 
-    the_title('<h1>', '</h1>');
+    the_title('<h2>', '</h2>');
 
     the_content();
     ?>

--- a/parts/post-type/single-ambassador.php
+++ b/parts/post-type/single-ambassador.php
@@ -1,6 +1,9 @@
 <article class="row column post-content">
     <?php
     $thumb = get_the_post_thumbnail_url(get_the_ID(), "medium");
+    $meta = get_post_custom(get_the_ID());
+    $ambassador_function = ! isset($meta['ambassador_function'][0]) ? '' : $meta['ambassador_function'][0];
+  
     if (! empty($thumb)) {
         ?>
         <a href="<?=esc_url(get_the_post_thumbnail_url(null, 'large'))?>" class="thumbnail nopad prop">
@@ -11,6 +14,10 @@
 
     the_title('<h1>', '</h1>');
 
+    if (!empty($ambassador_function)) { ?>
+            <p class="byline"><?=esc_html($ambassador_function);?></p>
+    <?php };
+  
     the_content();
     ?>
 </article>


### PR DESCRIPTION
I added extra information about the ambassador called `ambassador_function`.

To add this information, add a custom field in WordPress and call it `ambassador_function`. This is then displayed underneath the name at the overview page and underneath the name at the single ambassador page
Like this: \
![image](https://user-images.githubusercontent.com/23634586/56386071-24104680-6221-11e9-8a87-fef2cd0a2e27.png)

And like this: \
![image](https://user-images.githubusercontent.com/23634586/56386087-32f6f900-6221-11e9-9fc7-699c3a567e47.png)

In my opinion, this is relevant information to add to the ambassadors. I hope you like it!
