### PR TITLE
Fix ticket button to go to events.wisv.ch

### DIFF
--- a/parts/post-type/single-event.php
+++ b/parts/post-type/single-event.php
@@ -110,7 +110,7 @@ $category_list = is_array($categories) ? implode(', ', wp_list_pluck($categories
 			}
 
 			?>
-            <a class="button small" href="<?= site_url( '/events/' . $events_key ); ?>">
+            <a class="button small" href="<?= 'https://events.wisv.ch/' . $events_key; ?>">
                 <?= ($max_cost > 0) ? 'Get your ticket now' : 'Register now' ?>
             </a>
 			<?php


### PR DESCRIPTION
A quick fix for the register now / get your ticket now button. This is because events got moved from ch.tudelft.nl/events to events.wisv.ch.